### PR TITLE
Handle in-progress runs

### DIFF
--- a/components/Run.vue
+++ b/components/Run.vue
@@ -13,6 +13,9 @@
 			<span v-else-if="run.result === 'failed'" class="text-red-400" title="CI pipeline was a failure">
 				(F)
 			</span>
+			<span v-else-if="run.state === 'inProgress'" class="text-blue-400" title="CI pipeline is in progess">
+				(I)
+			</span>
 
 			&nbsp;
 

--- a/composables/pipelines_data/schema.ts
+++ b/composables/pipelines_data/schema.ts
@@ -7,9 +7,14 @@ export const run_validator = object({
 			href: string()
 		})
 	}),
+	state: union([
+		literal("completed"),
+		literal("inProgress")
+	]),
 	result: union([
 		literal("failed"),
-		literal("succeeded")
+		literal("succeeded"),
+		z.undefined()
 	]),
 	id: number()
 });

--- a/composables/pipelines_data/schema.ts
+++ b/composables/pipelines_data/schema.ts
@@ -1,4 +1,4 @@
-import { z, literal, number, object, string, union } from "zod";
+import { z, literal, number, object, string, undefined, union } from "zod";
 
 export type Run = z.infer<typeof run_validator>;
 export const run_validator = object({
@@ -14,7 +14,7 @@ export const run_validator = object({
 	result: union([
 		literal("failed"),
 		literal("succeeded"),
-		z.undefined()
+		undefined()
 	]),
 	id: number()
 });


### PR DESCRIPTION
Hi,

I think this fixes https://github.com/autumnblazey/atomcommunity-pipelines/issues/1.

### What this PR does

As I put it in the commit messages, this PR does (or tries to do):

- Successfully validating in-progress runs in `composables/pipelines_data/schema.ts`:

> In-progress pipeline runs won't have a `result`, but they will have `state: "inProgress"`.
>
> Meanwhile, completed pipeline runs have `state: "completed"`.
>
> Add `state` to the runs schema, validate its two possible options, ("completed" or "inProgress"),
> and allow `result` to be === `undefined`, in order to accommodate in-progress runs.

- Annotating in-progress runs with blue "(I)" text, (like the existing green "(S)" for successful runs and red "(F)" for failed runs.)

### Things to look out for / possible shortcomings of this PR

Two possible downsides or things to look out for with this PR:
- ~~I'm not sure if `zod.undefined()` would work on a fully missing object property, as opposed to a property with the value `undefined`???~~
  - ~~Testing needed. I didn't try testing this myself, it just looked basically right using the example data I posted in https://github.com/autumnblazey/atomcommunity-pipelines/issues/1.~~
  - Actually, I figured out how to test. It works on my machine. See screenshots below.
- I'm also not sure what happens if you query the **artifacts** API endpoint for an Azure Pipelines run that is early in-progress _without any artifacts attached to it yet_.
  - But that should be a thing that comes up when expanding a given run, after the main app has had a cahnce to present an overall dashboard, rather than a show-stopper issue that leaves the full app blank and un-rendered on the client-side, like the issue is now.

### Screenshots

#### Before

<details><summary>Before (click to expand)</summary>

![Web app that isn't showing anything but a solid color background.](https://user-images.githubusercontent.com/20157115/177017340-d758dd4c-8d36-4d49-9da0-7da41603b35c.png)

</details>

#### After

<details><summary>After (click to expand)</summary>

![Web app showing a dashboard of Azure Pipelines runs. The latest run shows a blue "(I)" to indicate it is in-progress.](https://user-images.githubusercontent.com/20157115/177017343-8875c0d1-a7d1-4f3b-b18a-3a853022f619.png)

</details>