### PR TITLE
Handle canceled runs as well

### DIFF
--- a/components/Run.vue
+++ b/components/Run.vue
@@ -13,6 +13,9 @@
 			<span v-else-if="run.result === 'failed'" class="text-red-400" title="CI pipeline was a failure">
 				(F)
 			</span>
+			<span v-else-if="run.result === 'canceled'" class="text-gray-400" title="CI pipeline was canceled">
+				(C)
+			</span>
 			<span v-else-if="run.state === 'inProgress'" class="text-blue-400" title="CI pipeline is in progess">
 				(I)
 			</span>

--- a/composables/pipelines_data/schema.ts
+++ b/composables/pipelines_data/schema.ts
@@ -12,6 +12,7 @@ export const run_validator = object({
 		literal("inProgress")
 	]),
 	result: union([
+		literal("canceled"),
 		literal("failed"),
 		literal("succeeded"),
 		undefined()


### PR DESCRIPTION
Hi again,

This is a follow-up to https://github.com/autumnblazey/atomcommunity-pipelines/pull/2 which added support for in-progress runs.

This PR adds validation to the schema, and run annotation in the UI, for _canceled runs_. The canceled runs are annotated in the UI with a gray "(C)".

So now in the UI there is:

- Succeeded: green "(S)"
- Failed: red "(R)"
- In-progress: blue "(I)"
- Canceled: gray "(C)"

### Testing/misc notes

I tested this by switching the pipeline URL (`list_runs_url` in `composables/pipelines_data/fetchers.ts`)  from pipeline 10 (which is the Release Branch Build pipeline, which isn't very busy and is generally all fails with one or two passes) to pipeline 9 (the PR pipeline, which is relatively busy and more likely to have in-progress runs, as well as having a few canceled runs from when people pushed new commits to the PR's branch part-way through an existing run. These get auto-canceled.) We probably won't have too many canceled runs on the main pipeline, but it's good to be ready just in case. And this does indeed work when tested against the PR pipeline with both in-progress and canceled runs.

### Screenshot

![Web app showing a canceled run, expanded, with only two macOS-related artifacts and atom-api.json available to download](https://user-images.githubusercontent.com/20157115/177442979-dd071ca3-7e88-4de3-8a41-7fe452aded46.png)